### PR TITLE
Fix GET method

### DIFF
--- a/src/Couchbase/Service/Couchbase.php
+++ b/src/Couchbase/Service/Couchbase.php
@@ -79,7 +79,7 @@ class Couchbase
             if(is_string($data->value))
                 $data = Json::decode($data->value, Json::TYPE_ARRAY);
             else
-                $data = $data->value;
+                $data = (array)$data->value;
         }
         catch(\CouchbaseException $e){ // The key don't exist
         	$data=null;

--- a/src/Couchbase/Service/Couchbase.php
+++ b/src/Couchbase/Service/Couchbase.php
@@ -75,9 +75,11 @@ class Couchbase
     {
 		try {
         	$data = $this->getCouchbaseClient()->get($key);
-
-        	// try to json decode data back to array
-        	$data = Json::decode($data->value, Json::TYPE_ARRAY);
+			// try to json decode data back to array if it's a string
+            if(is_string($data->value))
+                $data = Json::decode($data->value, Json::TYPE_ARRAY);
+            else
+                $data = $data->value;
         }
         catch(\CouchbaseException $e){ // The key don't exist
         	$data=null;


### PR DESCRIPTION
An edit from the web interface create an object, not an array or a string as value.

So the get method was updated to be sure that we have an array returned.